### PR TITLE
fix(config): support lumen config files

### DIFF
--- a/src/LaravelResourcesServiceProvider.php
+++ b/src/LaravelResourcesServiceProvider.php
@@ -47,7 +47,7 @@ class LaravelResourcesServiceProvider extends ServiceProvider
     {
         // Publishing the configuration file.
         $this->publishes([
-            __DIR__.'/../config/laravel-resources.php' => config_path('laravel-resources.php'),
+            __DIR__.'/../config/laravel-resources.php' => app()->basePath() . '/config/laravel-resources.php',
         ], 'config');
 
         // Registering package commands.

--- a/src/LaravelResourcesServiceProvider.php
+++ b/src/LaravelResourcesServiceProvider.php
@@ -47,7 +47,7 @@ class LaravelResourcesServiceProvider extends ServiceProvider
     {
         // Publishing the configuration file.
         $this->publishes([
-            __DIR__.'/../config/laravel-resources.php' => app()->basePath() . '/config/laravel-resources.php',
+            __DIR__.'/../config/laravel-resources.php' => app()->basePath().'/config/laravel-resources.php',
         ], 'config');
 
         // Registering package commands.


### PR DESCRIPTION


_Note:_
I know the `php artisan vendor` command is not available anyway for Lumen but still
the config file can be published (copied) manually.